### PR TITLE
Fix match() failing when query contains diacritics

### DIFF
--- a/src/match.js
+++ b/src/match.js
@@ -14,6 +14,7 @@ function escapeRegexCharacters(str) {
 
 module.exports = function match(text, query) {
   text = removeDiacritics(text);
+  query = removeDiacritics(query);
 
   return (
     query

--- a/src/match.test.js
+++ b/src/match.test.js
@@ -26,6 +26,10 @@ describe('match', function() {
     expect(match('Déjà vu', 'deja')).to.deep.equal([[0, 4]]);
   });
 
+  it('should highlight diacritics', function() {
+    expect(match('Déjà vu', 'déjà')).to.deep.equal([[0, 4]]);
+  });
+
   it('should sort the matches', function() {
     expect(match('Albert Einstein', 'e a')).to.deep.equal([[0, 1], [7, 8]]);
   });


### PR DESCRIPTION
Diacritics are removed from the text before searching for the query
string. This is basically fine, but we also have to remove diacritcs
from the query string. Otherwise, matching e.g. "flöte" in "Flöte" won't
work.

This fixes #7.