### PR TITLE
Fix for issue #18 - Special chars have unexpected behavior

### DIFF
--- a/src/match.test.js
+++ b/src/match.test.js
@@ -97,4 +97,42 @@ describe('match', function() {
       match('some sweet text', 's sweet', { requireMatchAll: true })
     ).to.deep.equal([[0, 1], [5, 10]]);
   });
+
+  it('should adjust indexes per original text typed with diactrics', function() {
+    expect(match('œuvre pompes test', 'pompes')).to.deep.equal([[6, 12]]);
+  });
+
+  it('should adjust indexes per original text typed with diactrics', function() {
+    expect(match('œuvre pompes test', 'œuvre')).to.deep.equal([[0, 5]]);
+  });
+
+  it('should adjust indexes per original text typed without diacritics', function() {
+    expect(match('œuvre pompes test', 'oeuvre')).to.deep.equal([[0, 5]]);
+  });
+
+  it('should match if diacritic is typed', function() {
+    expect(match('œuvre', 'œ')).to.deep.equal([[0, 1]]);
+  });
+
+  it('should match if diacritic is not typed', function() {
+    expect(match('œuvre', 'oe')).to.deep.equal([[0, 1]]);
+  });
+
+  it('should not match if part of diacritic is typed', function() {
+    expect(match('œuvre', 'o')).to.deep.equal([]);
+  });
+
+  it('should match single unicode character inside word', function() {
+    expect(match('ma sœur', 'oe', { insideWords: true })).to.deep.equal([
+      [4, 5]
+    ]);
+  });
+
+  it('should match beginning of second word including unicode character', function() {
+    expect(match('ma sœur', 'soe')).to.deep.equal([[3, 5]]);
+  });
+
+  it('should not match entire unicode character in middle of word if part of diacritic is typed', function() {
+    expect(match('ma sœur', 'so')).to.deep.equal([[3, 4]]);
+  });
 });

--- a/src/match.test.js
+++ b/src/match.test.js
@@ -1,7 +1,7 @@
 var expect = require('chai').expect;
 var match = require('./match');
 
-describe('match', function() {
+describe('match without options', function() {
   it('should highlight at the beginning of a word', function() {
     expect(match('some text', 'te')).to.deep.equal([[5, 7]]);
   });
@@ -10,33 +10,12 @@ describe('match', function() {
     expect(match('some text', 'e')).to.deep.equal([]);
   });
 
-  it('should highlight at the middle of a word', function() {
-    expect(match('some text', 'e', { insideWords: true })).to.deep.equal([
-      [3, 4]
-    ]);
-  });
-
   it('should highlight only the first match by default', function() {
     expect(match('some sweet text', 's')).to.deep.equal([[0, 1]]);
   });
 
   it('should highlight all the matches when query has multiple words', function() {
     expect(match('some sweet text', 's s')).to.deep.equal([[0, 1], [5, 6]]);
-  });
-
-  it('should highlight all the matches at the beginning of a word', function() {
-    expect(
-      match('some sweet text', 's', { findAllOccurrences: true })
-    ).to.deep.equal([[0, 1], [5, 6]]);
-  });
-
-  it('should highlight all the matches index words', function() {
-    expect(
-      match('some sweet text', 'e', {
-        insideWords: true,
-        findAllOccurrences: true
-      })
-    ).to.deep.equal([[3, 4], [7, 8], [8, 9], [12, 13]]);
   });
 
   it("should highlight when case doesn't match", function() {
@@ -86,27 +65,15 @@ describe('match', function() {
     expect(match('some text', 's sweet')).to.deep.equal([[0, 1]]);
   });
 
-  it('should not highlight anything', function() {
-    expect(
-      match('some text', 's sweet', { requireMatchAll: true })
-    ).to.deep.equal([]);
-  });
-
-  it('should highlight all words in query', function() {
-    expect(
-      match('some sweet text', 's sweet', { requireMatchAll: true })
-    ).to.deep.equal([[0, 1], [5, 10]]);
-  });
-
-  it('should adjust indexes per original text typed with diactrics', function() {
+  it('should adjust indexes per original text with diacritics ', function() {
     expect(match('œuvre pompes test', 'pompes')).to.deep.equal([[6, 12]]);
   });
 
-  it('should adjust indexes per original text typed with diactrics', function() {
+  it('should adjust indexes per original text if query typed with diacritics', function() {
     expect(match('œuvre pompes test', 'œuvre')).to.deep.equal([[0, 5]]);
   });
 
-  it('should adjust indexes per original text typed without diacritics', function() {
+  it('should adjust indexes per original text if query typed without diacritics', function() {
     expect(match('œuvre pompes test', 'oeuvre')).to.deep.equal([[0, 5]]);
   });
 
@@ -122,17 +89,60 @@ describe('match', function() {
     expect(match('œuvre', 'o')).to.deep.equal([]);
   });
 
+  it('should match beginning of second word including diacritic character', function() {
+    expect(match('ma sœur', 'soe')).to.deep.equal([[3, 5]]);
+  });
+
+  // This is a little weird, but I think the match should not be interrupted as a user
+  // types the individual characters of the query.
+  it('should not match entire diacritic character in middle of word if part of diacritic is typed', function() {
+    expect(match('ma sœur', 'so')).to.deep.equal([[3, 4]]);
+  });
+});
+
+describe('match with options', function() {
+  it('should highlight at the middle of a word', function() {
+    expect(match('some text', 'e', { insideWords: true })).to.deep.equal([
+      [3, 4]
+    ]);
+  });
+
+  it('should highlight at the end of a word', function() {
+    expect(match('some text', 'me', { insideWords: true })).to.deep.equal([
+      [2, 4]
+    ]);
+  });
+
   it('should match single unicode character inside word', function() {
     expect(match('ma sœur', 'oe', { insideWords: true })).to.deep.equal([
       [4, 5]
     ]);
   });
 
-  it('should match beginning of second word including unicode character', function() {
-    expect(match('ma sœur', 'soe')).to.deep.equal([[3, 5]]);
+  it('should highlight all the matches at the beginning of a word', function() {
+    expect(
+      match('some sweet text', 's', { findAllOccurrences: true })
+    ).to.deep.equal([[0, 1], [5, 6]]);
   });
 
-  it('should not match entire unicode character in middle of word if part of diacritic is typed', function() {
-    expect(match('ma sœur', 'so')).to.deep.equal([[3, 4]]);
+  it('should highlight all the matches index words', function() {
+    expect(
+      match('some sweet text', 'e', {
+        insideWords: true,
+        findAllOccurrences: true
+      })
+    ).to.deep.equal([[3, 4], [7, 8], [8, 9], [12, 13]]);
+  });
+
+  it('should not highlight anything', function() {
+    expect(
+      match('some text', 's sweet', { requireMatchAll: true })
+    ).to.deep.equal([]);
+  });
+
+  it('should highlight all words in query', function() {
+    expect(
+      match('some sweet text', 's sweet', { requireMatchAll: true })
+    ).to.deep.equal([[0, 1], [5, 10]]);
   });
 });

--- a/src/parse.test.js
+++ b/src/parse.test.js
@@ -78,4 +78,34 @@ describe('parse', function() {
       }
     ]);
   });
+
+  it('should highlight second word when first word contains œ', function() {
+    expect(parse('œuvre pompes test', [[6, 12]])).to.deep.equal([
+      {
+        text: 'œuvre ',
+        highlight: false
+      },
+      {
+        text: 'pompes',
+        highlight: true
+      },
+      {
+        text: ' test',
+        highlight: false
+      }
+    ]);
+  });
+
+  it('should highlight only first word that contains œ', function() {
+    expect(parse('œuvre pompes test', [[0, 5]])).to.deep.equal([
+      {
+        text: 'œuvre',
+        highlight: true
+      },
+      {
+        text: ' pompes test',
+        highlight: false
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
This is to fix the issue where some individual special characters become two characters when the removeDiacritics function is called.

By creating an array of the original characters and then calling removeDiacritics on each character, which may expand to two characters within its current array position, we can get the original string's correct indexes for found matches by using the array created.

ex.
"œuvre" --> ["œ", "u", "v", "r", "e"] where the length of the string and array are the same
then ["œ", "u", "v", "r", "e"] --> ["oe", "u", "v", "r", "e"] so the length of the first array element is now 2 but the length of the array is still the same as the length of the original string

If "oe" is the query then the first element of the array is matched and we can tell that was the first character in the original string so the match should be [0, 1] instead of [0, 2]