### PR TITLE
Fix match() failing when query contains cyrillic letters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,11 +5,10 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "autosuggest-highlight",
-      "version": "3.2.0",
+      "version": "3.2.1",
       "license": "MIT",
       "dependencies": {
-        "diacritic": "0.0.2"
+        "remove-accents": "^0.4.2"
       },
       "devDependencies": {
         "chai": "^4.1.2",
@@ -914,11 +913,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "node_modules/diacritic": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/diacritic/-/diacritic-0.0.2.tgz",
-      "integrity": "sha1-/CqIe1pbwKCoVPthTHwvIJBh7gQ="
     },
     "node_modules/diffie-hellman": {
       "version": "5.0.2",
@@ -7111,6 +7105,11 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
+    },
     "node_modules/remove-trailing-separator": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.0.2.tgz",
@@ -8925,11 +8924,6 @@
         "inherits": "^2.0.1",
         "minimalistic-assert": "^1.0.0"
       }
-    },
-    "diacritic": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/diacritic/-/diacritic-0.0.2.tgz",
-      "integrity": "sha1-/CqIe1pbwKCoVPthTHwvIJBh7gQ="
     },
     "diffie-hellman": {
       "version": "5.0.2",
@@ -13681,6 +13675,11 @@
         "is-equal-shallow": "^0.1.3",
         "is-primitive": "^2.0.0"
       }
+    },
+    "remove-accents": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/remove-accents/-/remove-accents-0.4.2.tgz",
+      "integrity": "sha512-7pXIJqJOq5tFgG1A2Zxti3Ht8jJF337m4sowbuHsW30ZnkQFnDzy9qBNhgzX8ZLW4+UBcXiiR7SwR6pokHsxiA=="
     },
     "remove-trailing-separator": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "precommit": "lint-staged"
   },
   "dependencies": {
-    "diacritic": "0.0.2"
+    "remove-accents": "^0.4.2"
   },
   "devDependencies": {
     "chai": "^4.1.2",

--- a/src/match.js
+++ b/src/match.js
@@ -1,4 +1,4 @@
-var removeDiacritics = require('diacritic').clean;
+var removeDiacritics = require('remove-accents').remove;
 
 // https://developer.mozilla.org/en/docs/Web/JavaScript/Guide/Regular_Expressions#Using_special_characters
 var specialCharsRegex = /[.*+?^${}()|[\]\\]/g;

--- a/src/match.test.js
+++ b/src/match.test.js
@@ -145,4 +145,10 @@ describe('match with options', function() {
       match('some sweet text', 's sweet', { requireMatchAll: true })
     ).to.deep.equal([[0, 1], [5, 10]]);
   });
+
+  it('should highlight case-insensitive with cyrillic letters', function() {
+    expect(match('БАЗИЛИК', 'базил', { requireMatchAll: true })).to.deep.equal([
+      [0, 5]
+    ]);
+  });
 });


### PR DESCRIPTION
Replaced Diactric.js with [remove-accents](https://github.com/tyxla/remove-accents).
Diactric.js contains an open [bug](https://github.com/nijikokun/Diacritics.js/issues/6) for cyrillic 'л' letter witch wasn't fixed more than three years. But remove-accents works with cyrillic correctly.

